### PR TITLE
Autofill

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Liuz Pokharel
 
 Matthew Tou
 
+Nathaniel Heidemann
+
 Ryan Hsiao
 
 Sohdai Yokokawa

--- a/public/index.html
+++ b/public/index.html
@@ -16,12 +16,20 @@
 				<button id="searchbar-submit">Go!</button>
 			</div>
 			<div id="searchbar-results">
-				<p hidden="">Pavilion</p>
-				<p hidden="" data-alt="YWDC,DC">Yablokoff Wallace Dining Center</p>
+				<p hidden="" data-alt="AOA">Academic Office Annex</p>
+				<p hidden="">Administration Building</p>
+				<p hidden="" data-alt="ACS">Arts and Computational Sciences Building</p>
+				<p hidden="" data-alt="BSP">Biomedical Sciences and Physics Building</p>
 				<p hidden="" data-alt="COB1,COB 1">Classroom Office Building 1</p>
 				<p hidden="" data-alt="COB2,COB 2">Classroom Office Building 2</p>
-				<p hidden="" data-alt="SRE1,SRE 1">Science and Engineering 1</p>
-				<p hidden="" data-alt="SRE2,SRE 2">Science and Engineering 2</p>
+				<p hidden="" data-alt="KL,Leo and Dottie Kolligian Library">Kolligian Library</p>
+				<p hidden="">Pavilion</p>
+				<p hidden="" data-alt="SE1,SE 1">Science and Engineering 1</p>
+				<p hidden="" data-alt="SE2,SE 2">Science and Engineering 2</p>
+				<p hidden="" data-alt="SSM">Social Sciences and Management Building</p>
+				<p hidden="" data-alt="SSB">Student Services Building</p>
+				<p hidden="" data-alt="SRE">Sustainability Research and Engineering Building</p>
+				<p hidden="" data-alt="YWDC,DC">Yablokoff Wallace Dining Center</p>
 			</div>
 		</div>
 		<img id="background-map" class="hidden-image" style="visibility:hidden;" src="assets/planet_-120.4419,37.3527_-120.4029,37.3762-wireframe.png"></img>

--- a/public/index.html
+++ b/public/index.html
@@ -9,9 +9,20 @@
 	<body>
 		<canvas id="canvas"></canvas>
 		<div id="compass">&lt;N</div>
-		<div id="searchbar"> <!-- May add more elements around bar or add jQuery UI stuff -->
-			<input id="searchbar-data">
-			<button id="searchbar-submit">Go!</button>
+		<div id="searchbar">
+			<!-- May add more elements around bar or add jQuery UI stuff -->
+			<div>
+				<input id="searchbar-data">
+				<button id="searchbar-submit">Go!</button>
+			</div>
+			<div id="searchbar-results">
+				<p hidden="">Pavilion</p>
+				<p hidden="" data-alt="YWDC,DC">Yablokoff Wallace Dining Center</p>
+				<p hidden="" data-alt="COB1,COB 1">Classroom Office Building 1</p>
+				<p hidden="" data-alt="COB2,COB 2">Classroom Office Building 2</p>
+				<p hidden="" data-alt="SRE1,SRE 1">Science and Engineering 1</p>
+				<p hidden="" data-alt="SRE2,SRE 2">Science and Engineering 2</p>
+			</div>
 		</div>
 		<img id="background-map" class="hidden-image" style="visibility:hidden;" src="assets/planet_-120.4419,37.3527_-120.4029,37.3762-wireframe.png"></img>
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>

--- a/public/js/autofill.mjs
+++ b/public/js/autofill.mjs
@@ -1,0 +1,120 @@
+class MultiMatcher {
+	constructor(s, d) {
+		this.str = s;
+		this.next = [];
+		this.data = d;
+	}
+
+	insert(x, dat) {
+		// there are 3 cases:
+		// the entire string x is a substring of this.str,
+		// 	and x may equal this.str
+		// the entire string this.str is a substring of x,
+		// 	but x is not equal to this.str
+		// x[0...n] is a substring of this.str[0...n]
+		// 	where n < min(this.str.length, x.length)
+		let same = 0;
+		let ml = 0;
+		if (x.length > this.str.length)
+			ml = this.str.length;
+		else
+			ml = x.length;
+		while (same < ml && this.str[same] == x[same]) {
+			same++;
+		}
+		if (same == x.length) {
+			if (this.str.length != same) {
+				this.next.push(new MultiMatcher(this.str.slice(same), this.data));
+				this.str = x;
+			}
+			this.data = dat;
+		} else if (same == this.str.length) {
+			x = x.slice(same);
+			for (const n of this.next) {
+				if (n.str.length > 0 && n.str[0] == x[0])
+					return n.insert(x, dat);
+			}
+			this.next.push(new MultiMatcher(x, dat));
+		} else {
+			let a = new MultiMatcher(x.slice(same), dat);
+			let b = new MultiMatcher(this.str.slice(same), this.data);
+			b.next = this.next;
+			this.str = x.slice(0, same);
+			this.next = [a, b];
+			this.data = null;
+		}
+	}
+
+	// match is case insensitive for the input, x[i...x.length]
+	// HOWEVER: the instance owner must ensure inserted strings are
+	// lowercase, as ONLY x is made lowercase during the match
+	match(x, i=0) {
+		let same = i;
+		let ml = 0;
+		if (x.length - i > this.str.length)
+			ml = this.str.length + i;
+		else
+			ml = x.length;
+		while (same < ml && this.str[same - i] == x[same].toLowerCase()) {
+			same++;
+		}
+		let l = same - i;
+		if (same == x.length)
+			return this;
+		for (const n of this.next) {
+			if (n.str.length > 0 && n.str[0] == x[same])
+				return n.match(x, same);
+		}
+		return null;
+	}
+
+	walk(act) {
+		act(this.data);
+		for (const n of this.next) {
+			n.walk(act);
+		}
+	}
+}
+
+const sbInput = document.getElementById("searchbar-data");
+const sbResults = document.getElementById("searchbar-results");
+const afTargets = new MultiMatcher("", null);
+
+function setupAutofill() {
+	// populate afTargets
+	// Not using simple <p> elements with data-alt for synonyms anymore?
+	// Update this section to properly extract the target values from the
+	// elements under sbResults
+	for (let entry of sbResults.children) {
+		entry.onclick = (ev) => {
+			ev.stopPropagation();
+			sbInput.value = ev.target.innerHTML;
+			// TODO: do the search, move and zoom map, etc.
+		};
+		let altNames = entry.dataset["alt"];
+		if (altNames) {
+			altNames = altNames.split(',');
+			for (const n of altNames) {
+				afTargets.insert(n.toLowerCase(), entry);
+			}
+		}
+		afTargets.insert(entry.innerHTML.toLowerCase(), entry);
+	}
+	sbInput.addEventListener("input", (ev) => {
+		// Here, we go over the input string completely each call even
+		// if only one character changed, because the event does not
+		// seem to tell me where the change occured
+		for (let entry of sbResults.children) {
+			entry.hidden = true;
+		}
+		let found = afTargets.match(sbInput.value);
+		if (found && found != afTargets) {
+			found.walk((n) => {
+				if (n)
+					n.hidden = false;
+			});
+		}
+	});
+}
+
+export { setupAutofill };

--- a/public/js/main.mjs
+++ b/public/js/main.mjs
@@ -4,6 +4,7 @@
 import { Camera, addCameraListeners, mergeLeft } from "./camera.mjs";
 import { Equirectangular, SphereMercator } from "./cartography.mjs";
 import { addSearchbarListeners } from "./searchbar.mjs";
+import { setupAutofill } from "./autofill.mjs";
 
 const ctx = $("#canvas")[0].getContext("2d");
 const camera = new Camera(ctx);
@@ -59,6 +60,7 @@ $(window).on("resize", function (e) {
 
 resize();
 draw();
+setupAutofill();
 
 // Debugging help
 window.draw = draw;

--- a/public/styles.css
+++ b/public/styles.css
@@ -36,3 +36,21 @@ html {
 	top: 0.5em;
 	margin: auto;
 }
+
+#searchbar-results {
+	color: white;
+	background-color: black;
+}
+
+#searchbar-results p {
+	margin-top: 1px;
+	margin-bottom: 1px;
+	padding-left: 3px;
+	border: 1px solid #ccc;
+	transition: background-color 0.2s, color 0.2s;
+}
+
+#searchbar-results p:hover {
+	color: black;
+	background-color: white;
+}


### PR DESCRIPTION
Autofill targets are initialized from the children of the node \#searchbar-results. The childrens' inner HTML is the main name of the target, and the comma separated names in the data-alt attribute are synonyms that can also be searched for. Not all of the targets have been added, but many have for testing. Targets are stored in a trie. Everything is created with setupAutofill().

Currently, plain nodes are stored as values, but this may be changed to some kind of { node, feature } if a feature array is created. Another idea is to add a data-feature attribute, in which case very little would change. Either way, this will wait on the implementation of some kind of feature list.

It might be a good idea to move the contents of autofill.mjs to searchbar.mjs in the future.

I threw my name in the README as well.